### PR TITLE
Fix offline bug, Update offlien yaml, Update config

### DIFF
--- a/main.yaml
+++ b/main.yaml
@@ -4,6 +4,9 @@
     - vars/undercloud_install.yaml
     - vars/undercloud_services.yaml
   tasks:
+    - name: Check Hardware
+      import_tasks: tasks/check_prepared.yaml
+
     - name: Create stack user
       import_tasks: tasks/create_stack_user.yaml
 

--- a/tasks/check_prepared.yaml
+++ b/tasks/check_prepared.yaml
@@ -1,3 +1,7 @@
 ---
-- name: check rpm exist
+- name: Check undercloud memory requirement
+  assert:
+    that:
+      - ansible_memtotal_mb >= 8192
+    msg: "Undercloud  install reqire at least 8192MB RAM"
   

--- a/tasks/install_deps.yaml
+++ b/tasks/install_deps.yaml
@@ -11,11 +11,12 @@
     patterns: '^python2-tripleo-repos-\w*.*\d*.centos.noarch.rpm$'
     use_regex: yes
   register: find_repo
+  when: offline_install == false
 
 - name: Try download TripleO repo from internet
   script: >
     tools/get_tripleo_repo
-  when: find_repo.matched == 0 and offline_install == false
+  when: offline_install == false
 
 - name: Find download tripleo repo
   find:
@@ -28,20 +29,23 @@
 - name: TripleO repo is "{{ find_repo.files[0].path | basename }}"
   set_fact:
     repo_name: "{{ find_repo.files[0].path | basename }}"
+  when: offline_install == false
 
 - name: Try copy rpm from local to remote server
   copy:
     src: "/tmp/{{ repo_name }}"
     dest: "/tmp/{{ repo_name }}"
-  when: find_repo.matched == 1
+  when: offline_install == false
 
 - name: Install TripleO repo
   yum:
     name: "/tmp/{{ python_tripleo_repo }}"
+  when: offline_install == false
 
 - name: Enable TripleO repo
   shell: tripleo-repos -b "{{ tripleo_version }}" current ceph
   become: true
+  when: offline_install == false
   tags: tripleo-rpm
 
 - name: Install pkgs

--- a/tasks/install_deps.yaml
+++ b/tasks/install_deps.yaml
@@ -1,22 +1,9 @@
 ---
-- name: Update System
-  yum:
-    name: '*'
-    state: latest
-  tags: yum_update
-
-- name: Try to find tripleo repo
-  find:
-    paths: /tmp
-    patterns: '^python2-tripleo-repos-\w*.*\d*.centos.noarch.rpm$'
-    use_regex: yes
-  register: find_repo
-  when: offline_install == false
-
 - name: Try download TripleO repo from internet
   script: >
     tools/get_tripleo_repo
   when: offline_install == false
+  tags: tripleo-rpm
 
 - name: Find download tripleo repo
   find:
@@ -25,33 +12,41 @@
     use_regex: yes
   register: find_repo
   when: offline_install == false
+  tags: tripleo-rpm
 
-- name: TripleO repo is "{{ find_repo.files[0].path | basename }}"
+- name: TripleO repo find "{{ find_repo.files[0].path | basename }}"
   set_fact:
     repo_name: "{{ find_repo.files[0].path | basename }}"
   when: offline_install == false
-
-- name: Try copy rpm from local to remote server
-  copy:
-    src: "/tmp/{{ repo_name }}"
-    dest: "/tmp/{{ repo_name }}"
-  when: offline_install == false
+  tags: tripleo-rpm
 
 - name: Install TripleO repo
   yum:
     name: "/tmp/{{ python_tripleo_repo }}"
   when: offline_install == false
 
-- name: Enable TripleO repo
+- name: Enable TripleO repo "{{ tripleo_version }}"
   shell: tripleo-repos -b "{{ tripleo_version }}" current ceph
   become: true
   when: offline_install == false
   tags: tripleo-rpm
 
-- name: Install pkgs
+- name: Install tripleo client
   yum:
     name:
       - python-tripleoclient
-      - vim
-      - tmux
+  tags: install-pkgs
+
+- name: Install ceph-ansible for external ceph
+  yum:
+    name:
+      - ceph-ansible
+  when: external_ceph == true
+  tags: install-pkgs
+
+- name: Install Extra pkgs
+  yum:
+    name: "{{ item }}"
+  with_items: "{{ extra_pkgs }}"
+  when: extra_pkgs | length > 0
   tags: install-pkgs

--- a/templates/undercloud.conf.j2
+++ b/templates/undercloud.conf.j2
@@ -13,13 +13,9 @@ network_cidr = {{ network_cidr }}
 masquerade_network = {{ masquerade_network }}
 local_ip = {{ local_ip }}
 network_gateway = {{ network_gateway }}
-undercloud_public_host = {{ undercloud_public_host }}
-undercloud_admin_host = {{ undercloud_admin_host }}
 dhcp_start = {{ dhcp_start }}
 dhcp_end = {{ dhcp_end }}
 inspection_iprange = {{ inspection_iprange }}
-undercloud_public_vip = {{ undercloud_public_vip }}
-undercloud_admin_vip = {{ undercloud_admin_vip }}
 
 [auth]
 undercloud_admin_password = {{ undercloud_admin_password }}

--- a/undercloud_config.yaml
+++ b/undercloud_config.yaml
@@ -90,6 +90,10 @@ inspection_iprange: 192.168.24.16,192.168.24.17
 # Offline
 offline_install: false
 
+# Undercloud will install ceph-ansible for use external ceph
+# (boolean)
+external_ceph: false
+
 # TripleO version
 tripleo_version: pike
 
@@ -100,3 +104,11 @@ tripleo_version: pike
 undercloud_fqdn: undercloud.inwinstak.com
 # Undercloud hostname to config /etc/hosts
 undercloud_hostname: undercloud
+
+#############################################
+# Undercloud install extra packages (options)
+#############################################
+
+# Install extra packages (list value)
+# eg. extra_pkgs: [vim, iperf3, sl]
+extra_pkgs: [vim, tmux]

--- a/undercloud_config.yaml
+++ b/undercloud_config.yaml
@@ -29,7 +29,7 @@ undercloud_debug: true
 
 # Whether to update packages during the Undercloud install. (boolean
 # value)
-undercloud_update_packages: true
+undercloud_update_packages: false
 
 # Whether to install Tempest in the Undercloud. (boolean value)
 enable_tempest: false
@@ -75,14 +75,14 @@ network_gateway: 192.168.24.1
 
 # Start of DHCP allocation range for PXE and DHCP of Overcloud
 # instances. (string value)
-dhcp_start: 192.168.24.4
+dhcp_start: 192.168.24.5
 
 # End of DHCP allocation range for PXE and DHCP of Overcloud
 # instances. (string value)
-dhcp_end: 192.168.24.15
+dhcp_end: 192.168.24.25
 
 #Inspection ip range use the same cidr with deploy format 
-inspection_iprange: 192.168.24.16,192.168.24.17
+inspection_iprange: 192.168.24.100,192.168.24.120
 
 ###################################
 # Undercloud host config (required)


### PR DESCRIPTION
Fix offline install bug 
- Because the reigster changed after modify. ansible when will fail.i
  Only use offline var.
- Remove unused undercloud conf templates vars

Update offline yaml and config 
- update offline yaml directly download from internet
- add config install ceph-ansible for external ceph
- add extra_pkgs var to add a list of extra packages not hardcode in play.


Add check memory update default config 
- Add task check memory >= 8G on host
- Update inspector range and dhcp range for default usage